### PR TITLE
Fix platform version error in `Package.swift`

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -33,17 +33,26 @@
         "repositoryURL": "https://github.com/swiftwasm/JavaScriptKit.git",
         "state": {
           "branch": null,
-          "revision": "8ba4135d5fd6a734c3771ef3fac66896bbcb0214",
-          "version": "0.8.0"
+          "revision": "b7a02434c6e973c08c3fd5069105ef44dd82b891",
+          "version": "0.9.0"
         }
       },
       {
         "package": "OpenCombine",
-        "repositoryURL": "https://github.com/MaxDesiatov/OpenCombine.git",
+        "repositoryURL": "https://github.com/TokamakUI/OpenCombine.git",
         "state": {
           "branch": null,
-          "revision": "29ab27e488a1c9afef217b1435b3293d4a77b1ae",
-          "version": "0.0.1"
+          "revision": "eea5e707b571da14fce588000046b8ec4c62018b",
+          "version": "0.12.0-alpha3"
+        }
+      },
+      {
+        "package": "OpenCombineJS",
+        "repositoryURL": "https://github.com/swiftwasm/OpenCombineJS.git",
+        "state": {
+          "branch": null,
+          "revision": "5e8636b15bcb4b8900696d95daaab941458ed2cf",
+          "version": "0.0.2"
         }
       },
       {
@@ -95,8 +104,8 @@
         "package": "Tokamak",
         "repositoryURL": "https://github.com/TokamakUI/Tokamak.git",
         "state": {
-          "branch": "publish-support",
-          "revision": "aed4fc37ec74aa67b1f9135f5d43ffdecee11c1c",
+          "branch": "main",
+          "revision": "25e2191154e56db40db03924aa71716c2fe79cde",
           "version": null
         }
       }

--- a/Package.swift
+++ b/Package.swift
@@ -1,33 +1,37 @@
 // swift-tools-version:5.3
-// The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
   name: "TokamakPublish",
-  platforms: [.macOS(.v10_15)],
+  platforms: [.macOS(.v11)],
   products: [
-    // Products define the executables and libraries a package produces, and make them visible to other packages.
     .library(
       name: "TokamakPublish",
       targets: ["TokamakPublish"]
     ),
   ],
   dependencies: [
-    // Dependencies declare other packages that this package depends on.
     .package(url: "https://github.com/JohnSundell/Publish.git", from: "0.7.0"),
     .package(url: "https://github.com/TokamakUI/Tokamak.git", .branch("main")),
   ],
   targets: [
-    // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-    // Targets can depend on other targets in this package, and on products in packages this package depends on.
     .target(
       name: "TokamakPublish",
-      dependencies: ["Publish", .product(name: "TokamakStaticHTML", package: "Tokamak")]
+      dependencies: [
+        .product(
+          name: "Publish",
+          package: "Publish"
+        ),
+        .product(
+          name: "TokamakStaticHTML",
+          package: "Tokamak"
+        )
+      ]
     ),
     .testTarget(
       name: "TokamakPublishTests",
-      dependencies: ["TokamakPublish"]
+      dependencies: [.target(name: "TokamakPublish")]
     ),
   ]
 )


### PR DESCRIPTION
This PR fixes the following error:

```plaintext
The package product 'TokamakStaticHTML' requires minimum platform version 11.0 for the macOS platform, but this target supports 10.15
```