### PR TITLE
Add a direct link to Publish in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TokamakPublish
 
-Use Tokamak for your Publish themes.
+Use Tokamak in your themes for [the Publish static generator](https://github.com/johnsundell/Publish).
 
 You can either write your entire theme with Tokamak, or integrate it with your existing `Plot` HTML.
 


### PR DESCRIPTION
This should help users who haven't heard of Publish before, and all other users who'd like to navigate directly to Publish from the `README.md` file.